### PR TITLE
Bump up image version

### DIFF
--- a/scaling-deployment.yaml
+++ b/scaling-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: wbuchwalter/kubernetes-acs-engine-autoscaler:0.3.0
+        image: wbuchwalter/kubernetes-acs-engine-autoscaler:latest
         env:
         - name: AZURE_SP_APP_ID
           valueFrom:


### PR DESCRIPTION
I discovered that the --acs-deployment flag option does not exist in the 0.3.0 tag for the image