### PR TITLE
Fix cordon/uncordon logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ $ python main.py [options]
 - --spare-agents: Number of agent per pool that should always stay up (default is 1)
 - --acs-deployment: The name of the deployment used to deploy the kubernetes cluster initially
 - --idle-threshold: Maximum duration (in seconds) an agent can stay idle before being deleted
+- --util-threshold: Utilization of a node in percent under which it is considered under utilized and should be cordoned
 - --over-provision: Number of extra agents to create when scaling up, default to 0.
 
 ## Windows Machine Pools

--- a/autoscaler/cluster.py
+++ b/autoscaler/cluster.py
@@ -178,7 +178,7 @@ class Cluster(object):
         for pod in pods:
             fitting = None
             for node in nodes:
-                if node.can_fit(pod.resources):
+                if node.can_fit(pod.resources) and not node.unschedulable:
                     fitting = node
                     break
             if fitting is None:

--- a/autoscaler/cluster.py
+++ b/autoscaler/cluster.py
@@ -30,7 +30,7 @@ pykube.http.requests.packages.urllib3.connection.match_hostname = backports.ssl_
 logger = logging.getLogger(__name__)
 
 class Cluster(object):
-    def __init__(self, kubeconfig, idle_threshold, spare_agents, 
+    def __init__(self, kubeconfig, idle_threshold, util_threshold, spare_agents, 
                  service_principal_app_id, service_principal_secret, service_principal_tenant_id,
                  kubeconfig_private_key, client_private_key, ca_private_key,
                  instance_init_time, resource_group, notifier, ignore_pools,
@@ -54,6 +54,7 @@ class Cluster(object):
         self.instance_init_time = instance_init_time
         self.spare_agents = spare_agents
         self.idle_threshold = idle_threshold
+        self.util_threshold = util_threshold
         self.over_provision = over_provision
         self.scale_up = scale_up
         self.maintainance = maintainance
@@ -113,8 +114,8 @@ class Cluster(object):
                 return self.loop_logic()
             except CloudError as e:
                 logger.error(e)
-            except:
-                logger.warn("Unexpected error: {}".format(sys.exc_info()[0]))
+            except BaseException as e:
+                logger.warn("Unexpected error: {}".format(e))
                 return False
     
     def create_kube_node(self, node):
@@ -142,6 +143,7 @@ class Cluster(object):
             over_provision=self.over_provision,
             spare_count=self.spare_agents,
             idle_threshold=self.idle_threshold,
+            util_threshold=self.util_threshold,
             notifier=self.notifier)
 
         pods = list(map(KubePod, pykube.Pod.objects(self.api)))

--- a/autoscaler/engine_scaler.py
+++ b/autoscaler/engine_scaler.py
@@ -19,17 +19,16 @@ from autoscaler.template_processing import prepare_template_for_scale_out
 
 logger = logging.getLogger(__name__)
 
-
 class EngineScaler(Scaler):
 
     def __init__(
             self, resource_group, nodes,
-            over_provision, spare_count, idle_threshold, dry_run,
+            over_provision, spare_count, idle_threshold, util_threshold, dry_run,
             deployments, arm_template, arm_parameters, ignore_pools, notifier):
 
         Scaler.__init__(
             self, resource_group, nodes, over_provision,
-            spare_count, idle_threshold, dry_run, deployments, notifier)
+            spare_count, idle_threshold, util_threshold, dry_run, deployments, notifier)
 
         self.arm_parameters = arm_parameters
         self.arm_template = arm_template

--- a/autoscaler/kube.py
+++ b/autoscaler/kube.py
@@ -140,6 +140,7 @@ class KubeNode(object):
         try:
             self.original.reload()
             self.original.obj['spec']['unschedulable'] = False
+            self.original.obj['metadata']['labels'][_CORDON_LABEL] = 'false'
             self.original.update()
             logger.info("uncordoned %s", self)
             return True

--- a/autoscaler/kube.py
+++ b/autoscaler/kube.py
@@ -65,7 +65,9 @@ class KubePod(object):
         determines whether the pod is in a grace period for draining
         this prevents us from draining pods that are too new
         """
-        return not self.start_time or (datetime.datetime.now(self.start_time.tzinfo) - self.start_time) < self._DRAIN_GRACE_PERIOD
+        #return not self.start_time or (datetime.datetime.now(self.start_time.tzinfo) - self.start_time) < self._DRAIN_GRACE_PERIOD
+        # disable pod grace_period, as this seems to cause more problem than benefits for most users
+        return True
 
     def is_drainable(self):
         return self.is_replicated() and not self.is_critical() and not self.is_in_drain_grace_period()

--- a/autoscaler/scaler.py
+++ b/autoscaler/scaler.py
@@ -179,7 +179,9 @@ class Scaler(object):
         if num_unaccounted:
             logger.warn('Failed to scale sufficiently.')
             self.notifier.notify_failed_to_scale(selectors_hash, pods)
+    
         self.scale_pools(new_pool_sizes)
+
         if self.notifier:
             self.notifier.notify_scale(new_pool_sizes, pods, current_pool_sizes)
         

--- a/autoscaler/scaler.py
+++ b/autoscaler/scaler.py
@@ -30,12 +30,9 @@ class ClusterNodeState(object):
 
 
 class Scaler(object):
+    # UTIL_THRESHOLD = 0.3
 
-    # the utilization threshold under which to consider a node
-    # under utilized and drainable
-    UTIL_THRESHOLD = 0.3
-
-    def __init__(self, resource_group, nodes, over_provision, spare_count, idle_threshold, dry_run, deployments, notifier):
+    def __init__(self, resource_group, nodes, over_provision, spare_count, idle_threshold, util_threshold, dry_run, deployments, notifier):
         self.resource_group_name = resource_group
         self.over_provision = over_provision
         self.spare_count = spare_count
@@ -43,6 +40,9 @@ class Scaler(object):
         self.dry_run = dry_run
         self.deployments = deployments
         self.notifier = notifier
+        # the utilization threshold under which to consider a node
+        # under utilized 
+        self.util_threshold = util_threshold / 100
 
         # ACS support up to 100 agents today
         # TODO: how to handle case where cluster has 0 node? How to get unit
@@ -83,7 +83,7 @@ class Scaler(object):
             p.is_drainable() or 'kube-proxy' in p.name)]
 
         utilization = sum((p.resources for p in busy_list), KubeResource())
-        under_utilized = (self.UTIL_THRESHOLD *
+        under_utilized = (self.util_threshold *
                           node.capacity - utilization).possible 
         drainable = not undrainable_list
 

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ DEBUG_LOGGING_MAP = {
 #How many agents should we keep even if the cluster is not utilized? The autoscaler will currenty break if --spare-agents == 0
 @click.option("--spare-agents", default=1, help='number of agent per pool that should always stay up') 
 @click.option("--idle-threshold", default=1800, help='time in seconds an agent can stay idle')
+@click.option("--util-threshold", default=30, help='Utilization of a node in percent under which it is considered under utilized and should be cordoned')
 @click.option("--service-principal-app-id", default=None, envvar='AZURE_SP_APP_ID')
 @click.option("--service-principal-secret", default=None, envvar='AZURE_SP_SECRET')
 @click.option("--service-principal-tenant-id", default=None, envvar='AZURE_SP_TENANT_ID')
@@ -50,7 +51,7 @@ DEBUG_LOGGING_MAP = {
 def main(resource_group, acs_deployment, sleep, kubeconfig,
          service_principal_app_id, service_principal_secret,
          kubeconfig_private_key, client_private_key, ca_private_key,
-         service_principal_tenant_id, spare_agents, idle_threshold,
+         service_principal_tenant_id, spare_agents, idle_threshold, util_threshold,
          no_scale, over_provision, no_maintenance, ignore_pools, slack_hook,
          dry_run, verbose, debug):
     logger_handler = logging.StreamHandler(sys.stderr)
@@ -81,6 +82,7 @@ def main(resource_group, acs_deployment, sleep, kubeconfig,
                       instance_init_time=instance_init_time,
                       spare_agents=spare_agents,
                       idle_threshold=idle_threshold,
+                      util_threshold=util_threshold,
                       resource_group=resource_group,
                       acs_deployment=acs_deployment,
                       service_principal_app_id=service_principal_app_id,

--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -39,6 +39,7 @@ class TestCluster(unittest.TestCase):
         self.cluster = Cluster(
             kubeconfig='~/.kube/config',
             idle_threshold=60,
+            util_threshold=30,
             spare_agents=1,
             instance_init_time=60,
             resource_group='my-rg',

--- a/test/utils.py
+++ b/test/utils.py
@@ -17,4 +17,5 @@ def create_scaler(nodes):
         arm_template=template,
         ignore_pools='',
         idle_threshold=0,
+        util_threshold=30,
         notifier='')


### PR DESCRIPTION
Fix #7.
* Add a `--util-threshold` parameter to control the percentage of CPU utilization for a node under which it should be cordoned.
* The autoscaler will now uncordon existing unschedulable nodes before creating new ones
