### PR TITLE
upgraded azure-cli to 2.0.24

### DIFF
--- a/autoscaler/azure_api.py
+++ b/autoscaler/azure_api.py
@@ -2,7 +2,6 @@ import requests
 from adal.adal_error import AdalError
 from azure.cli.core._profile import Profile
 from adal.adal_error import AdalError
-from azure.cli.core.prompting import prompt_pass, NoTTYException
 import azure.cli.core.azlogging as azlogging
 from azure.cli.core.util import CLIError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ python-dateutil>=2.5.3
 cachetools>=2.0.0
 JSON-log-formatter>=0.1.0
 
-azure-cli==2.0.9
-azure.storage==0.34.0
-msrestazure==0.4.11
+azure-cli-core==2.0.24
+azure-cli==2.0.24
+azure.storage==0.36.0
+msrestazure==0.4.21
 
 # pykube>=0.12.0 we need master branch
 git+git://github.com/kelproject/pykube.git@8a5cd8f6babc013e11f02b9594fb534e9c58689f


### PR DESCRIPTION
Also removed the prompting package that wasn't used and no longer exists, which seems to make tests pass again.
I've tested this change on one of our clusters and checked that cluster successfully scales in and out, if there are more ways you can think of for making sure I didn't introduce breaking changes I would love to hear about it.